### PR TITLE
Prevent ordered_futures to swallow errors

### DIFF
--- a/lib/Ryu/Source.pm
+++ b/lib/Ryu/Source.pm
@@ -1153,10 +1153,10 @@ sub ordered_futures {
     my %pending;
     my $src_completed = $src->completed;
     my $all_finished = 0;
-    $self->completed->on_ready(sub {
+    $self->completed->on_ready($self->completed->$curry::weak(sub {
         $all_finished = 1;
-        $src->completed->done unless %pending or $src_completed->is_ready;
-    });
+        $src_completed->on_ready(shift) unless %pending;
+    }));
 
     $src_completed->on_ready(sub {
         my @pending = values %pending;


### PR DESCRIPTION
Errors that appear in the original source before reaching the ordered_futures is swallowed because of `$src_completed->done`, this will use `on_ready` to avoid that issue.